### PR TITLE
Needed to append prefixed_invite_path not replace it.

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -75,9 +75,14 @@ class Room < ApplicationRecord
     shared_users.include?(user)
   end
 
+  # Add a prefix to the invite path
+  def prefixed_invite_path
+    "#{ENV['INVITE_PREFIX'] || ''}#{self.invite_path}"
+  end
+
   # Determines the invite path for the room.
   def invite_path
-    "#{ENV['INVITE_PREFIX'] || ''}#{self.invite_path}"
+    "#{Rails.configuration.relative_url_root}/#{CGI.escape(uid)}"
   end
 
   # Notify waiting users that a meeting has started.


### PR DESCRIPTION
This seems to be causing a stack overflow as it recursively calls itself
incorrectly.